### PR TITLE
bump ember-getowner-polyfill to ^1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-sass": "^6.0.0",
-    "ember-getowner-polyfill": "^1.0.1",
+    "ember-getowner-polyfill": "^1.1.1",
     "object-assign": "^4.0.1",
     "rsvp": "^3.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,9 +1762,9 @@ ember-export-application-global@^1.0.5:
   dependencies:
     ember-cli-babel "^5.1.10"
 
-ember-getowner-polyfill@^1.0.1:
+ember-getowner-polyfill@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.1.1.tgz#6bb6603827dd2f8f33be2434570a86cc9e5273ff"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.1.1.tgz#6bb6603827dd2f8f33be2434570a86cc9e5273ff"
   dependencies:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
@@ -4387,7 +4387,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@~2.1.2:
+"readable-stream@1 || 2", readable-stream@^2, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@~2.1.2:
   version "2.1.5"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -4408,7 +4408,7 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:


### PR DESCRIPTION
ember-getowner-polyfill isn't actually a true polyfill until 1.1.0 Since we're using it as such, we should set to the most recent version.